### PR TITLE
Markdimarco/lin 17 refactor storage of items to avoid viewissue list mismatch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,11 +124,13 @@ impl App {
                         self.selected_issue_widget.handle_event(event);
                         if let LtEvent::SelectIssue = self.issue_list_widget.handle_event(event) {
                             let issue_list_widget_state =
-            self.issue_list_widget.state.write().unwrap();
+                                self.issue_list_widget.state.write().unwrap();
                             let selected_issue: Option<IssueFragment> = issue_list_widget_state
                                 .list_state
                                 .selected()
-                                .map(|index| issue_list_widget_state.issues[index].clone());
+                                .map(|index| {
+                                    issue_list_widget_state.issue_map[&self.issue_list_widget.selected_view_id][index].clone()
+                                });
                             self.selected_issue_widget
                                 .set_selected_issue(selected_issue);
                         }

--- a/src/widgets/issue_list.rs
+++ b/src/widgets/issue_list.rs
@@ -186,11 +186,6 @@ impl MyIssuesWidget {
                         self.scroll_up();
                         return LtEvent::SelectIssue;
                     }
-                    KeyCode::Char('r') => {
-                        //self.run(TabChangeEvent::FetchMyIssues);
-                        // TODO: Figure out how to get state to update better
-                        return LtEvent::SelectIssue;
-                    }
                     KeyCode::Char('o') => {
                         let _ = self.open_url();
                         return LtEvent::None;


### PR DESCRIPTION
### Description

The primary change updates the internal data structure that holds the issues together, which is currently in the issues_list widget:

```diff
#[derive(Debug, Default)]
pub struct MyIssuesWidgetState {
    loading_state: LoadingState,
    pub list_state: ListState,
-    pub issues: Vec<IssueFragment>,
+    pub issue_map: HashMap<String, Vec<IssueFragment>>,
}

#[derive(Debug, Clone, Default)]
pub struct MyIssuesWidget {
    pub state: Arc<RwLock<MyIssuesWidgetState>>,
+   pub selected_view_id: String,
}
```

Using `selected_view_id` as a lookup to the issue_map gives us:
1. a nice performance boost when switching back and forth between tabs, since we'll display the cached value while refreshing in the background
2. avoids any mismatch between `tab_widget`'s selected tab and `issue_list`'s issues, which could happen in v0.0.5 and below when tab/shift+tabbing fast