### PR TITLE
LIN-19 Better color schemes for light and dark themed terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "lt"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "chrono",
  "cli-clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lt"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 description = "An unofficial TUI client for Linear.app issues"
 authors = ["Mark Di Marco <mark.dimarco@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 * **New in 0.0.4**: View switcher (`Tab`/`Shift+Tab`) - switch between custom views as defined in your Linear app
 * **New in 0.0.6**: Now available to install view Homebrew (see **Installation**)
 * **New in 0.0.7**: Search issues (`/`) - search all issues by simple search term
+* **New in 0.0.9**: Much better color schemes for light and dark themed terminals
   
 ### Planned Features
 * Faster loading via cacheing

--- a/src/widgets/issue_list.rs
+++ b/src/widgets/issue_list.rs
@@ -5,11 +5,8 @@ use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Rect},
     style::{
-        Color, Modifier, Style, Stylize,
-        palette::{
-            material::{AMBER, BLUE_GRAY},
-            tailwind::SLATE,
-        },
+        palette::
+            material::AMBER, Color, Modifier, Style, Stylize
     },
     text::{Line, Span, Text},
     widgets::{Block, List, ListItem, ListState, Padding, Paragraph, StatefulWidget, Widget, Wrap},
@@ -271,7 +268,7 @@ impl MyIssuesWidget {
         LtEvent::None
     }
 }
-const SELECTED_STYLE: Style = Style::new().bg(SLATE.c100).fg(BLUE_GRAY.c900);
+const SELECTED_STYLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD).add_modifier(Modifier::ITALIC);
 
 impl Widget for &MyIssuesWidget {
     fn render(self, area: Rect, buf: &mut Buffer) {
@@ -329,8 +326,8 @@ impl Widget for &MyIssuesWidget {
                         priority_icon
                     );
                     text.extend([
-                        item.title.clone().white(),
-                        line.add_modifier(Modifier::BOLD).blue(),
+                        item.title.clone(),
+                        line.add_modifier(Modifier::BOLD).blue().to_string(),
                     ]);
                     ListItem::new(text)
                 })

--- a/src/widgets/selected_issue.rs
+++ b/src/widgets/selected_issue.rs
@@ -65,7 +65,7 @@ impl SelectedIssueWidget {
     }
 }
 
-const DICT_HEADER: Style = Style::new().fg(SLATE.c100);
+const DICT_HEADER: Style = Style::new();
 
 fn header(text: &str) -> Line {
     Line::from(Span::from(text.to_owned() + ":\n")).style(DICT_HEADER)
@@ -189,7 +189,7 @@ impl Widget for &SelectedIssueWidget {
                 ),
             };
 
-        let created_at_title = Line::from(created_at).fg(SLATE.c100).right_aligned();
+        let created_at_title = Line::from(created_at).right_aligned();
 
         // collapse borders for nicer UI
         let collapsed_top_and_left_border_set = symbols::border::Set {

--- a/src/widgets/tab_widget.rs
+++ b/src/widgets/tab_widget.rs
@@ -188,7 +188,7 @@ impl Widget for &TabWidget {
                     } else if tab.tab_type == TabType::SearchResults {
                         (iconmap::ico_to_nf("Magnify"), Color::Yellow.to_string())
                     } else {
-                        (iconmap::ico_to_nf("Home"), String::from("#FFFFFF"))
+                        (iconmap::ico_to_nf("Home"), Color::Blue.to_string())
                     };
                     let project_color = Color::from_str(&color).unwrap();
                     Span::from(format!("{} {}", icon, tab.title.clone().bold()))


### PR DESCRIPTION
### Old
Things looked terrible on light themes
<img width="1624" height="1056" alt="Screenshot 2025-07-12 at 12 34 43 PM" src="https://github.com/user-attachments/assets/f41cc2ba-7877-489c-b5d5-902f75f0a38d" />


### New
<img width="1624" height="1056" alt="Screenshot 2025-07-12 at 12 32 57 PM" src="https://github.com/user-attachments/assets/145d9856-518c-426d-a49e-e8f78801d379" />
<img width="1624" height="1056" alt="Screenshot 2025-07-12 at 12 31 35 PM" src="https://github.com/user-attachments/assets/6bc9d96a-3772-4f61-97ec-72c0ccf7caad" />
<img width="1624" height="1056" alt="Screenshot 2025-07-12 at 12 31 21 PM" src="https://github.com/user-attachments/assets/2a82c915-641b-4dff-8b03-38062728460b" />
