### PR TITLE
LIN-20 Adding empty state, fixing scroll issue

### DIFF
--- a/src/widgets/snapshots/lt__widgets__issue_list__tests__empty_state.snap
+++ b/src/widgets/snapshots/lt__widgets__issue_list__tests__empty_state.snap
@@ -3,7 +3,7 @@ source: src/widgets/issue_list.rs
 expression: terminal.backend()
 ---
 "┌──────────────────────────────────────────────────────────┐"
-"│                                                          │"
+"│No issues found                                           │"
 "│                                                          │"
 "│                                                          │"
 "│                                                          │"


### PR DESCRIPTION
Fixes an issue where an empty list (like an empty custom view, empty search results) would crash if a user tried to navigate issues via `j/k`

Also added an affordance if the list is empty and not being loading ("No issues found").